### PR TITLE
Added a pylintrc file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,6 @@ repos:
         types: [python]
         args:
           - "--recursive"
-          - "--rcfile=.pylintrc"
           - "y"
           - "."
   


### PR DESCRIPTION
This pull request addresses #3. Any other pylint checks can also be disabled in the future by updating the `.pylintrc` file. 
The pre-commit hook has also been configured to use the `.pylintrc` file while running pylint.
@Zshan0 have a look.