### PR TITLE
Generic grouping and Trotter combination implemented

### DIFF
--- a/src/grouping/__init__.py
+++ b/src/grouping/__init__.py
@@ -3,4 +3,5 @@ from .bitwise import (
     bitwise_representor,
     bitwise_gate,
     bitwise_operator_convertor,
+    Bitwise,
 )

--- a/src/grouping/bitwise.py
+++ b/src/grouping/bitwise.py
@@ -1,4 +1,5 @@
 from .grouper import Grouper
+from ..utils import get_el
 
 
 class Bitwise(Grouper):
@@ -83,10 +84,7 @@ def bitwise_representor(pauli_list: set[str]) -> str:
     if len(pauli_list) == 0:
         raise ValueError("Empty Group, no representation can be made.")
 
-    x = ""
-    for a in pauli_list:
-        x = a
-        break
+    x = get_el(pauli_list)
 
     repr_str = ["i"] * len(x)
 

--- a/src/grouping/grouper.py
+++ b/src/grouping/grouper.py
@@ -1,5 +1,4 @@
-from abc import abstractmethod  # Built in. No install needed.
-from typing import Iterable
+from abc import abstractmethod
 
 
 class Grouper:
@@ -11,7 +10,7 @@ class Grouper:
         self._commutable_sets = []
 
     @property
-    def groups(self) -> Iterable[Iterable[str]]:
+    def groups(self) -> list[set[str]]:
         return self._commutable_sets
 
     @abstractmethod

--- a/src/grouping/grouper.py
+++ b/src/grouping/grouper.py
@@ -1,0 +1,28 @@
+from abc import abstractmethod  # Built in. No install needed.
+from typing import Iterable
+
+
+class Grouper:
+    """
+    Abstract class for grouping algorithms.
+    """
+
+    def __init__(self, pauli_list: set[str]):
+        self._commutable_sets = []
+
+    @property
+    def groups(self) -> Iterable[Iterable[str]]:
+        return self._commutable_sets
+
+    @abstractmethod
+    def diagonalize(self, pauli_op: str) -> tuple[float, str]:
+        """
+        Gets the operator after it has been diagonlized by the circuit.
+        """
+
+    @abstractmethod
+    def circuit(self, pauli_op: str) -> list[str]:
+        """
+        Calls the gate constructor with the representor string stored. This
+        makes it easier for the user to access.
+        """

--- a/src/grouping/test_bitwise.py
+++ b/src/grouping/test_bitwise.py
@@ -4,6 +4,7 @@ from .bitwise import (
     bitwise_representor,
     bitwise_gate,
     bitwise_operator_convertor,
+    Bitwise,
 )
 
 pauli_lists = [
@@ -28,6 +29,10 @@ def test_commuting(pauli_list, grouped):
     result = bitwise_group(pauli_list)
     assert sorted(result) == sorted(grouped)
 
+    bitwise_grouper = Bitwise(pauli_list)
+
+    assert sorted(bitwise_grouper.groups) == sorted(grouped)
+
 
 comm_pauli_sets = [["zz", "ii"], ["xz", "xi", "ii"], ["ix", "xi"], ["ii"], ["ix", "ii"]]
 
@@ -49,6 +54,9 @@ def test_bitwise_gate(reprs, gates):
     result = bitwise_gate(reprs)
     assert sorted(result) == sorted(gates)
 
+    bitwise_grouper = Bitwise([reprs])
+    assert sorted(bitwise_grouper.circuit(reprs)) == sorted(gates)
+
 
 paulis = ["zz", "xz", "xy", "ii", "ix"]
 diags = [(1.0, "zz"), (1.0, "zz"), (-1.0, "zz"), (1.0, "ii"), (1.0, "iz")]
@@ -57,4 +65,9 @@ diags = [(1.0, "zz"), (1.0, "zz"), (-1.0, "zz"), (1.0, "ii"), (1.0, "iz")]
 @pytest.mark.parametrize("pauli,diag", zip(paulis, diags))
 def test_bitwise_conversion(pauli, diag):
     result = bitwise_operator_convertor(pauli)
+    assert result == diag
+
+    bitwise_grouper = Bitwise([])
+
+    result = bitwise_grouper.diagonalize(pauli)
     assert result == diag

--- a/src/ordering/__init__.py
+++ b/src/ordering/__init__.py
@@ -1,0 +1,1 @@
+from .lexico import lexico

--- a/src/ordering/lexico.py
+++ b/src/ordering/lexico.py
@@ -1,4 +1,4 @@
-def lexico(ops: list[str]) -> list[str]:
+def lexico(ops: set[str]) -> list[str]:
     """
     The given operators that are diagonalized already will be ordered qubitwise
     which comes out to be same strategy as lexicographic ordering.

--- a/src/ordering/lexico.py
+++ b/src/ordering/lexico.py
@@ -1,0 +1,6 @@
+def lexico(ops: list[str]) -> list[str]:
+    """
+    The given operators that are diagonalized already will be ordered qubitwise
+    which comes out to be same strategy as lexicographic ordering.
+    """
+    return sorted(ops)

--- a/src/ordering/test_grouping_utils.py
+++ b/src/ordering/test_grouping_utils.py
@@ -1,0 +1,13 @@
+import pytest
+from .lexico import lexico
+
+
+pauli_lists = [["ziz", "iiz", "zzz"]]
+ordered = [["iiz", "ziz", "zzz"]]
+
+
+@pytest.mark.parametrize("pauli_list,ordered", zip(pauli_lists, ordered))
+def test_op_order(pauli_list, ordered):
+    result = lexico(pauli_list)
+    for a, b in zip(result, ordered):
+        assert a == b

--- a/src/trotter_grouping/group_trotter.py
+++ b/src/trotter_grouping/group_trotter.py
@@ -1,0 +1,149 @@
+from typing import Callable
+from qiskit import QuantumCircuit
+
+from ..grouping.bitwise import (
+    bitwise_group,
+    bitwise_representor,
+    bitwise_gate,
+    bitwise_operator_convertor,
+)
+
+from ..grouping.grouper import Grouper
+
+from ..trotter.simple import trotter
+
+from ..utils import circuit_constructor, get_el
+
+
+def group_trotter(h: dict[str, float], t: float = 1.0) -> QuantumCircuit:
+    """
+    Runs simple Trotter for the case where all the elements of the Hamiltonian
+    are commuting Pauli operators. It uses rotation and exponentiation.
+
+    Inputs:
+        - h: Hamiltonian in dictionary form.
+        - t: Float representing time of evolution.
+    Returns: QuantumCircuit that will simulate the Hamiltonian
+    """
+
+    # Getting the group representation
+    representor = bitwise_representor(set(h.keys()))
+
+    # Getting the rotation and the anti-rotation circuit
+    rot_circuit = circuit_constructor(bitwise_gate(representor))
+    anti_rot_circuit = circuit_constructor(bitwise_gate(representor), True)
+
+    # Rotating the operators and then using them in Trotter.
+    rotated_operators = {}
+    for pauli, coeff in h.items():
+        coeff_c, new_pauli = bitwise_operator_convertor(pauli)
+        rotated_operators[new_pauli] = coeff * coeff_c
+
+    exp_circ = trotter(rotated_operators, t)
+
+    final_circuit = rot_circuit.compose(exp_circ)
+    final_circuit = final_circuit.compose(anti_rot_circuit)
+    return final_circuit
+
+
+def generic(
+    grouper: Grouper,
+    orderer: Callable[[set[str]], list[str]],
+    h: dict[str, float],
+    t: float = 1.0,
+    reps: int = 1,
+) -> QuantumCircuit:
+    """
+    A generic trotterization constructor.
+
+    Inputs:
+        - grouper: Pauli grouper
+        - orderer: Function that orders the diagonalized terms
+        - h: Hamiltonian in dictionary form
+        - t: Float representing time of evolution
+        - reps: Repetitions for Trotterization.
+    Returns: QuantumCircuit that will simulate the Hamiltonian
+    """
+    pauli_list = set(h.keys())
+
+    if len(pauli_list) == 0:
+        raise ValueError("Input Hamiltonian was empty.")
+
+    # size of any pauli operator
+    first = get_el(pauli_list)
+    num_qubits = len(first)
+
+    grouper = Grouper(pauli_list)
+    groups = grouper.groups
+    group_circs = []
+
+    # Get relevant circuits for all the groups
+    for group in groups:
+        pauli = get_el(group)
+        diag_circ = circuit_constructor(grouper.circuit(pauli))
+        diag_circ_c = diag_circ.inverse()
+
+        diag_ham = {}
+        for p in group:
+            coeff, term = grouper.diagonalize(p)
+            diag_ham[term] = h[p] * coeff
+
+        # time will be scaled down by reps
+        exp_circ = trotter(diag_ham, t / reps)
+
+        final_circuit = QuantumCircuit(num_qubits)
+
+        # TODO: Issue 30
+        # Combining the three sections
+        final_circuit = diag_circ.compose(exp_circ)
+        final_circuit = final_circuit.compose(diag_circ_c)
+        group_circs.append(final_circuit)
+
+    final_circuit = QuantumCircuit(num_qubits)
+    for _ in range(reps):
+        for group_circ in group_circs:
+            final_circuit = final_circuit.compose(group_circ)
+
+    return final_circuit
+
+
+def bitwise_simple(
+    h: dict[str, float], t: float = 1.0, reps: int = 1
+) -> QuantumCircuit:
+    """
+    Takes in a Hamiltonian and constructs the simple Trotterization circuit
+    after grouping the terms together.
+
+    Inputs:
+        - h: Hamiltonian in dictionary form.
+        - t: Float representing time of evolution.
+        - reps: Repetitions for Trotterization.
+    Returns: QuantumCircuit that will simulate the Hamiltonian
+    """
+    pauli_list = set(h.keys())
+
+    if len(pauli_list) == 0:
+        raise ValueError("Input Hamiltonian was empty.")
+
+    # size of any pauli operator
+
+    first = ""
+    for x in pauli_list:
+        first = x
+        break
+
+    num_qubits = len(first)
+
+    groups = bitwise_group(pauli_list)
+    grouped_hs = [{pauli: h[pauli] for pauli in group} for group in groups]
+
+    # Using rotation and anti-rotation functionality, time must be divided
+    trotter_circs = [group_trotter(h_i, t / reps) for h_i in grouped_hs]
+    final_circuit = QuantumCircuit(num_qubits)
+
+    # Repeating
+    for _ in range(reps):
+        for circ in trotter_circs:
+            final_circuit = final_circuit.compose(circ)
+
+    return final_circuit

--- a/src/trotter_grouping/group_trotter.py
+++ b/src/trotter_grouping/group_trotter.py
@@ -1,53 +1,15 @@
 from typing import Callable
 from qiskit import QuantumCircuit
 
-from ..grouping.bitwise import (
-    bitwise_group,
-    bitwise_representor,
-    bitwise_gate,
-    bitwise_operator_convertor,
-)
-
 from ..grouping.grouper import Grouper
 
-from ..trotter.simple import trotter
+from ..trotter.simple import trotter_from_terms
 
 from ..utils import circuit_constructor, get_el
 
 
-def group_trotter(h: dict[str, float], t: float = 1.0) -> QuantumCircuit:
-    """
-    Runs simple Trotter for the case where all the elements of the Hamiltonian
-    are commuting Pauli operators. It uses rotation and exponentiation.
-
-    Inputs:
-        - h: Hamiltonian in dictionary form.
-        - t: Float representing time of evolution.
-    Returns: QuantumCircuit that will simulate the Hamiltonian
-    """
-
-    # Getting the group representation
-    representor = bitwise_representor(set(h.keys()))
-
-    # Getting the rotation and the anti-rotation circuit
-    rot_circuit = circuit_constructor(bitwise_gate(representor))
-    anti_rot_circuit = circuit_constructor(bitwise_gate(representor), True)
-
-    # Rotating the operators and then using them in Trotter.
-    rotated_operators = {}
-    for pauli, coeff in h.items():
-        coeff_c, new_pauli = bitwise_operator_convertor(pauli)
-        rotated_operators[new_pauli] = coeff * coeff_c
-
-    exp_circ = trotter(rotated_operators, t)
-
-    final_circuit = rot_circuit.compose(exp_circ)
-    final_circuit = final_circuit.compose(anti_rot_circuit)
-    return final_circuit
-
-
 def generic(
-    grouper: Grouper,
+    grouper_class: Callable[[set[str]], Grouper],
     orderer: Callable[[set[str]], list[str]],
     h: dict[str, float],
     t: float = 1.0,
@@ -73,23 +35,28 @@ def generic(
     first = get_el(pauli_list)
     num_qubits = len(first)
 
-    grouper = Grouper(pauli_list)
+    grouper = grouper_class(pauli_list)
     groups = grouper.groups
     group_circs = []
 
     # Get relevant circuits for all the groups
     for group in groups:
         pauli = get_el(group)
+
+        # Diagonalizing circuits
         diag_circ = circuit_constructor(grouper.circuit(pauli))
         diag_circ_c = diag_circ.inverse()
 
-        diag_ham = {}
-        for p in group:
+        # Setting the order according to ordere
+        ordered = orderer(group)
+        ordered_tuples = []
+        for p in ordered:
             coeff, term = grouper.diagonalize(p)
-            diag_ham[term] = h[p] * coeff
+            coeff = (t / reps) * h[p] * coeff
+            ordered_tuples.append((term, coeff))
 
         # time will be scaled down by reps
-        exp_circ = trotter(diag_ham, t / reps)
+        exp_circ = trotter_from_terms(ordered_tuples)
 
         final_circuit = QuantumCircuit(num_qubits)
 
@@ -103,47 +70,5 @@ def generic(
     for _ in range(reps):
         for group_circ in group_circs:
             final_circuit = final_circuit.compose(group_circ)
-
-    return final_circuit
-
-
-def bitwise_simple(
-    h: dict[str, float], t: float = 1.0, reps: int = 1
-) -> QuantumCircuit:
-    """
-    Takes in a Hamiltonian and constructs the simple Trotterization circuit
-    after grouping the terms together.
-
-    Inputs:
-        - h: Hamiltonian in dictionary form.
-        - t: Float representing time of evolution.
-        - reps: Repetitions for Trotterization.
-    Returns: QuantumCircuit that will simulate the Hamiltonian
-    """
-    pauli_list = set(h.keys())
-
-    if len(pauli_list) == 0:
-        raise ValueError("Input Hamiltonian was empty.")
-
-    # size of any pauli operator
-
-    first = ""
-    for x in pauli_list:
-        first = x
-        break
-
-    num_qubits = len(first)
-
-    groups = bitwise_group(pauli_list)
-    grouped_hs = [{pauli: h[pauli] for pauli in group} for group in groups]
-
-    # Using rotation and anti-rotation functionality, time must be divided
-    trotter_circs = [group_trotter(h_i, t / reps) for h_i in grouped_hs]
-    final_circuit = QuantumCircuit(num_qubits)
-
-    # Repeating
-    for _ in range(reps):
-        for circ in trotter_circs:
-            final_circuit = final_circuit.compose(circ)
 
     return final_circuit

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,4 @@
 from .norm import circuit_eq
 from .repr import qiskit_string_repr
 from .circuit import circuit_constructor
+from .sample import get_el

--- a/src/utils/sample.py
+++ b/src/utils/sample.py
@@ -1,0 +1,3 @@
+def get_el(sset: set):
+    for x in sset:
+        return x


### PR DESCRIPTION
Performing trotter with other Pauli grouping techniques has been made easier by creating a common generic function that takes in a grouper and an ordered. The grouper class has been previously implemented, setting a standard API for any Pauli grouping technique.